### PR TITLE
Reorganized to avoid direct DOM manipulation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,16 +4,31 @@ import SidePanel from "./components/SidePanel";
 import axios from "axios";
 
 function App() {
-  const [selectedBoard, setSelectedBoard] = useState(null);
+  const [selectedBoard, setSelectedBoard] = useState(-1);
   const [cards, setCards] = useState([]);
 
-  const onSelectBoard = (event) => {
-    setSelectedBoard(event.target.value);
+  const onSelectBoard = (id) => {
+    setSelectedBoard(id);
+
+    if (id < 0) {
+      refreshCards(id);
+    }
   };
 
   const onDisplayBoard = () => {
+    refreshCards();
+  };
+
+  const refreshCards = (overrideId) => {
+    const boardId = overrideId || selectedBoard;
+
+    if (boardId < 0) {
+      setCards([]);
+      return;
+    }
+
     axios
-      .get(`${process.env.REACT_APP_BACKEND_URL}/boards/${selectedBoard}/cards`)
+      .get(`${process.env.REACT_APP_BACKEND_URL}/boards/${boardId}/cards`)
       .then((response) => {
         console.log(response);
         const responseCards = response.data.cards;
@@ -45,7 +60,7 @@ function App() {
       />
       <Board
         className="board"
-        setCards={setCards}
+        onUpdateCards={refreshCards}
         cards={cards}
         selectedBoard={selectedBoard}
       />

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -2,7 +2,7 @@ import React from "react";
 import Card from "./Card";
 import "./SidePanel";
 
-const Board = ({ cards, setCards }) => {
+const Board = ({ cards, onUpdateCards }) => {
   const cardsList = cards.map((card) => {
     return (
       <Card
@@ -10,8 +10,7 @@ const Board = ({ cards, setCards }) => {
         cardId={card.cardId}
         message={card.message}
         likesCount={card.likesCount}
-        setCards={setCards}
-        cards={cards}
+        onUpdate={onUpdateCards}
       />
     );
   });

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,19 +1,16 @@
 import axios from "axios";
-import React, { useState } from "react";
+import React from "react";
 import "./SidePanel";
 import { MdDeleteForever } from "react-icons/md";
 import { FcLike } from "react-icons/fc";
 
-const Card = ({ cardId, message, likesCount }) => {
-  let [likes, setLikes] = useState(likesCount);
+const Card = ({ cardId, message, likesCount, onUpdate }) => {
 
   const onCardLike = (event) => {
     axios
       .patch(`${process.env.REACT_APP_BACKEND_URL}/cards/${cardId}`)
       .then((response) => {
-        setLikes((likes += 1));
-        const likesNumber = document.querySelector(`#likesDisplay${cardId}`);
-        likesNumber.textContent = `Likes:${likes}`;
+        onUpdate()
       })
       .catch((error) => console.log(error));
   };
@@ -23,16 +20,13 @@ const Card = ({ cardId, message, likesCount }) => {
     axios
       .delete(`${process.env.REACT_APP_BACKEND_URL}/cards/${cardId}`)
       .then((response) => {
-        console.log(response);
-        const deletedCard = document.querySelector(`[name='Card${cardId}']`);
-        console.log(deletedCard);
-        deletedCard.remove();
+        onUpdate()
       })
       .catch((error) => console.log(error));
   };
 
   return (
-    <div className="card-main" id={cardId} name={`Card${cardId}`}>
+    <div className="card-main">
       <span className="card-text">{message}</span>
 
       <div className="card-footer">
@@ -41,7 +35,7 @@ const Card = ({ cardId, message, likesCount }) => {
           size="1.3em"
           onClick={() => onCardLike()}
         />
-        <small id={`likesDisplay${cardId}`}>Likes: {likes}</small>
+        <small>Likes: {likesCount}</small>
         <MdDeleteForever
           className="delete-icon"
           size="1.3em"

--- a/src/components/CreateBoard.js
+++ b/src/components/CreateBoard.js
@@ -8,7 +8,7 @@ const makeEmptyBoardFields = () => {
   };
 };
 
-const CreateBoard = () => {
+const CreateBoard = ({onCreateBoard}) => {
   const [boardFields, setBoardFields] = useState(makeEmptyBoardFields());
   const [errorMessage, setErrorMessage] = useState("");
   // const [submitted, setSubmitted] = useState(false);
@@ -38,13 +38,7 @@ const CreateBoard = () => {
       .then((response) => {
         // setValid(true);
         // setSubmitted(true);
-        const boardList = document.getElementById("board-list");
-        const newBoard = document.createElement("option");
-        newBoard.value = response.data.board.board_id;
-        newBoard.id = response.data.board.board_id;
-        const boardTitle = document.createTextNode(response.data.board.title);
-        newBoard.appendChild(boardTitle);
-        boardList.appendChild(newBoard);
+        onCreateBoard();
         setBoardFields(makeEmptyBoardFields());
         setErrorMessage("");
         // console.log(response.data.board.title);

--- a/src/components/CreateCard.js
+++ b/src/components/CreateCard.js
@@ -14,6 +14,8 @@ const CreateCard = ({ selectedBoard, onDisplayBoard }) => {
   };
 
   const handleSaveClick = () => {
+    if (selectedBoard < 0) { return; }
+
     axios
       .post(
         `${process.env.REACT_APP_BACKEND_URL}/boards/${selectedBoard}/cards`,

--- a/src/components/SelectBoard.js
+++ b/src/components/SelectBoard.js
@@ -1,34 +1,21 @@
-import axios from "axios";
-import { useEffect } from "react";
+const SelectBoard = ({ onSelectBoard, selectedBoard, boardList, onDisplayBoard }) => {
 
-const SelectBoard = ({ onSelectBoard, setCurrentBoards, onDisplayBoard }) => {
-  useEffect(() => {
-    axios
-      .get(`${process.env.REACT_APP_BACKEND_URL}/boards`)
-      .then((response) => {
-        const boards = response.data[0];
-        setCurrentBoards((prevState) => {
-          prevState = boards;
-        });
-        const boardList = document.getElementById("board-list");
+  const boardValue = selectedBoard || "";
+  console.log(boardValue);
 
-        for (let board of boards) {
-          let newBoard = document.createElement("option");
-          newBoard.value = board.board_id;
-          newBoard.id = board.board_id;
-          const boardTitle = document.createTextNode(board.title);
-          newBoard.appendChild(boardTitle);
-          boardList.appendChild(newBoard);
-        }
-      })
-      .catch((error) => console.log(error));
-  }, []);
+  const onSelectChange = (event) => {
+    const id = parseInt(event.target.value);
+    onSelectBoard(id);
+  };
 
   return (
     <section className="board-selector">
       <h3>Select Board to Display</h3>
-      <select id="board-list" onChange={onSelectBoard}>
-        <option>-- Select Board --</option>
+      <select id="board-list" onChange={onSelectChange} value={boardValue}>
+        <option value={-1}>-- Select Board --</option>
+        { boardList.map(board => (
+          <option key={board.board_id} value={board.board_id}>{board.title}</option>
+        )) }
       </select>
       <button className="display-board" onClick={onDisplayBoard}>
         Display Selected Board

--- a/src/components/SidePanel.js
+++ b/src/components/SidePanel.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import axios from "axios";
 import CreateCard from "./CreateCard";
 import CreateBoard from "./CreateBoard";
@@ -6,35 +6,49 @@ import SelectBoard from "./SelectBoard";
 
 const SidePanel = ({
   selectedBoard,
-  handleAddCard,
   onSelectBoard,
   onDisplayBoard,
 }) => {
   const [currentBoards, setCurrentBoards] = useState([]);
 
-  const onDeleteBoard = () => {
+  const refreshBoards = () => {
     axios
-      .delete(`${process.env.REACT_APP_BACKEND_URL}/boards/${selectedBoard}`)
+      .get(`${process.env.REACT_APP_BACKEND_URL}/boards`)
       .then((response) => {
-        console.log("response", response);
-        const boardId = selectedBoard;
-        console.log("selectedBoard", selectedBoard);
-        const deletedBoard = document.getElementById(boardId);
-        deletedBoard.remove();
+        const boards = response.data[0];
+        setCurrentBoards(boards);
       })
       .catch((error) => console.log(error));
   };
+
+  const onDeleteBoard = () => {
+    if (selectedBoard < 0) { return; }
+
+    axios
+      .delete(`${process.env.REACT_APP_BACKEND_URL}/boards/${selectedBoard}`)
+      .then((response) => {
+        onSelectBoard(-1);
+        refreshBoards();
+      })
+      .catch((error) => console.log(error));
+  };
+
+  useEffect(() => {
+    refreshBoards();
+  }, []);
 
   return (
     <div className="sidepanel-main">
       <SelectBoard
         onSelectBoard={onSelectBoard}
-        setCurrentBoards={setCurrentBoards}
+        selectedBoard={selectedBoard}
+        boardList={currentBoards}
         onDisplayBoard={onDisplayBoard}
       />
-      <CreateBoard />
+      <CreateBoard 
+        onCreateBoard={refreshBoards}
+      />
       <CreateCard
-        handleAddCard={handleAddCard}
         selectedBoard={selectedBoard}
         onDisplayBoard={onDisplayBoard}
       />


### PR DESCRIPTION
Some suggestions on how to display the board and card data without DOM manipulation.
With React, we generally avoid mixing React rendering with DOM manipulation, as it can lead to a mismatch in what React thinks the DOM currently looks like, and what it actually looks like, leading to errors when it tries to modify a node which isn't there.
My main approach was to locate the pieces of code performing direct DOM manipulation, identifying what piece of state should drive the rendering instead, then make sure that the state, and whatever functions were needed to update them,  were being passed wherever it needed to be.
Some of the modifications aren't _necessary_, but I found the extra step of needing to click the show button for a board to see the cards to be a little confusing at times. You might consider automatically switching the cards as soon as the selection changes so that there's no confusion around whether the currently displayed board in the list is the same as the cards.
Notice how the main way we trigger UI updates involves setting state to notify React about a change, and then React re-renders, using the new data, leading to different elements showing up in the page.